### PR TITLE
JavaScript plugin

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -68,11 +68,11 @@ jobs:
       - name: Export UPLOAD_URL
         id: export_upload_url
         run: echo "upload_url=${{ steps.create_release.outputs.upload_url }}" >> $GITHUB_OUTPUT
-  updload-java:
+  upload-java:
     name: Upload Java Plugin
     runs-on: ubuntu-latest
     needs: build
-    steps: 
+    steps:
       - name: Import plugin JAR files
         id: import_jar_files
         uses: actions/download-artifact@v3
@@ -80,7 +80,7 @@ jobs:
           name: ecocode-plugins
           path: lib
       - name: Upload Release Asset - Java Plugin
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -89,11 +89,32 @@ jobs:
           asset_path: lib/ecocode-java-plugin-${{ needs.build.outputs.last_tag }}.jar
           asset_name: ecocode-java-plugin-${{ needs.build.outputs.last_tag }}.jar
           asset_content_type: application/zip
-  updload-php:
+  upload-javascript:
+    name: Upload JavaScript Plugin
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Import plugin JAR files
+        id: import_jar_files
+        uses: actions/download-artifact@v3
+        with:
+          name: ecocode-plugins
+          path: lib
+      - name: Upload Release Asset - JavaScript Plugin
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{needs.build.outputs.upload_url}}
+          asset_path: lib/ecocode-javascript-plugin-${{ needs.build.outputs.last_tag }}.jar
+          asset_name: ecocode-javascript-plugin-${{ needs.build.outputs.last_tag }}.jar
+          asset_content_type: application/zip
+  upload-php:
     name: Upload PHP Plugin
     runs-on: ubuntu-latest
     needs: build
-    steps: 
+    steps:
       - name: Import plugin JAR files
         id: import_jar_files
         uses: actions/download-artifact@v3
@@ -101,7 +122,7 @@ jobs:
           name: ecocode-plugins
           path: lib
       - name: Upload Release Asset - PHP Plugin
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -110,11 +131,11 @@ jobs:
           asset_path: lib/ecocode-php-plugin-${{ needs.build.outputs.last_tag }}.jar
           asset_name: ecocode-php-plugin-${{ needs.build.outputs.last_tag }}.jar
           asset_content_type: application/zip
-  updload-python:
+  upload-python:
     name: Upload Python Plugin
     runs-on: ubuntu-latest
     needs: build
-    steps: 
+    steps:
       - name: Import plugin JAR files
         id: import_jar_files
         uses: actions/download-artifact@v3
@@ -122,7 +143,7 @@ jobs:
           name: ecocode-plugins
           path: lib
       - name: Upload Release Asset - Python Plugin
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Export UPLOAD_URL
         id: export_upload_url
         run: echo "upload_url=${{ steps.create_release.outputs.upload_url }}" >> $GITHUB_OUTPUT
-  updload-java:
+  upload-java:
     name: Upload Java Plugin
     runs-on: ubuntu-latest
     needs: build
@@ -69,7 +69,28 @@ jobs:
           asset_path: lib/ecocode-java-plugin-${{ github.ref_name }}.jar
           asset_name: ecocode-java-plugin-${{ github.ref_name }}.jar
           asset_content_type: application/zip
-  updload-php:
+  upload-javascript:
+    name: Upload JavaScript Plugin
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Import plugin JAR files
+        id: import_jar_files
+        uses: actions/download-artifact@v3
+        with:
+          name: ecocode-plugins
+          path: lib
+      - name: Upload Release Asset - JavaScript Plugin
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{needs.build.outputs.upload_url}}
+          asset_path: lib/ecocode-javascript-plugin-${{ github.ref_name }}.jar
+          asset_name: ecocode-javascript-plugin-${{ github.ref_name }}.jar
+          asset_content_type: application/zip
+  upload-php:
     name: Upload PHP Plugin
     runs-on: ubuntu-latest
     needs: build
@@ -90,7 +111,7 @@ jobs:
           asset_path: lib/ecocode-php-plugin-${{ github.ref_name }}.jar
           asset_name: ecocode-php-plugin-${{ github.ref_name }}.jar
           asset_content_type: application/zip
-  updload-python:
+  upload-python:
     name: Upload Python Plugin
     runs-on: ubuntu-latest
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [#44](https://github.com/green-code-initiative/ecoCode/pull/44) Update the PHP description rules
+- [#67](https://github.com/green-code-initiative/ecoCode/pull/67) Add JavaScript plugin
 
 ### Changed
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,11 +1,13 @@
 - [Installation notes / requirements](#installation-notes--requirements)
 - [Project structure](#project-structure)
-- [Links](#links)
+- [Plugin-specific guides](#plugin-specific-guides)
 
 Installation notes / requirements
 ---------------------------------
 
-Please read common [INSTALL.md](https://github.com/green-code-initiative/ecoCode-common/blob/main/doc/INSTALL.md) in `ecoCode-common` repository.
+Please read common [INSTALL.md](https://github.com/green-code-initiative/ecoCode-common/blob/main/doc/INSTALL.md)
+in `ecoCode-common` repository. Please follow the specific guides below for additional information on installing the
+desired plugins.
 
 Project structure
 -----------------
@@ -28,9 +30,10 @@ ecoCode                 # Root directory
 
 You will find more information about the plugins’ architecture in their folders
 
-Links
------
+Plugin-specific guides
+----------------------
 
-- Java how-to : https://github.com/SonarSource/sonar-java/blob/master/docs/CUSTOM_RULES_101.md
-- Python how-to : https://github.com/SonarSource/sonar-custom-rules-examples/tree/master/python-custom-rules
-- PHP how-to : https://github.com/SonarSource/sonar-custom-rules-examples/tree/master/php-custom-rules
+- [Java how-to](java-plugin/README.md)
+- [JavaScript how-to](javascript-plugin/README.md)
+- [Python how-to](python-plugin/README.md)
+- [PHP how-to](php-plugin/README.md)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,13 +13,15 @@ Project structure
 Here is a preview of project tree :
 
 ```txt
-ecoCode              # Root directory
+ecoCode                 # Root directory
 |
-+--java-plugin       # JAVA
++--java-plugin          # JAVA
 |
-+--php-plugin        # PHP
++--javascript-plugin    # JavaScript
 |
-+--python-plugin     # Python
++--php-plugin           # PHP
+|
++--python-plugin        # Python
 |
 \--docker-compose.yml   # Docker compose file
 ```

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 ![Logo](docs/resources/logo-large.png)
 ======================================
 
-*ecoCode* is a collective project aiming to reduce environmental footprint of software at the code level. The goal of
+_ecoCode_ is a collective project aiming to reduce environmental footprint of software at the code level. The goal of
 the project is to provide a list of static code analyzers to highlight code structures that may have a negative
 ecological impact: energy and resources over-consumption, "fatware", shortening terminals' lifespan, etc.
 
-ecoCode is based on evolving catalogs of [good practices](docs/rules), for various technologies. A SonarQube plugin then
-implement these catalogs as rules for scanning your projects.
+_ecoCode_ is based on evolving catalogs of [good practices](docs/rules), for various technologies. A SonarQube plugin
+then implement these catalogs as rules for scanning your projects.
 
 **Warning**: this is still a very early stage project. Any feedback or contribution will be highly appreciated. Please
 refer to the contribution section.
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/green-code-initiative/ecoCode-common/blob/main/doc/CODE_OF_CONDUCT.md)
 
 🌿 SonarQube Plugins
 -------------------
 
-4 technologies are supported by the plugin right now:
+4 technologies are supported by ecoCode right now:
 
 - [Java](java-plugin/)
 - [JavaScript](javascript-plugin/)
@@ -32,10 +32,10 @@ refer to the contribution section.
 
 There is two kind of plugins :
 
-- One for web / backoffice (PHP, Python, Java, JavaScript), using smells described in the 2nd edition of the repository published in
-  september 2015
+- One for web / backoffice (PHP, Python, Java, JavaScript), using smells described in the 2nd edition of the repository
+  published in september 2015.
   You can find all the
-  rules [here (in french)](https://docs.google.com/spreadsheets/d/1nujR4EnajnR0NSXjvBW3GytOopDyTfvl3eTk2XGLh5Y/edit#gid=1386834576)
+  rules [here (in french)](https://docs.google.com/spreadsheets/d/1nujR4EnajnR0NSXjvBW3GytOopDyTfvl3eTk2XGLh5Y/edit#gid=1386834576).
   The current repository is for web / backOffice
 - One for mobile (Android), using [a set of smells](https://olegoaer.perso.univ-pau.fr/android-energy-smells/) theorised
   by Olivier Le Goaër for Android.
@@ -46,7 +46,9 @@ There is two kind of plugins :
 Code is parsed to be transformed as AST. AST will allow you to access one or more nodes of your code.
 For example, you’ll be able to access of all your `for` loop, to explore content etc.
 
-To better understand AST structure, y a can use [AST Explorer](https://astexplorer.net/)
+To better understand AST structure, you can use the [AST Explorer](https://astexplorer.net/).
+
+JavaScript plugin works differently because it does not use AST. [More information here](javascript-plugin/README.md)
 
 🚀 Getting Started
 ------------------

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ refer to the contribution section.
 🌿 SonarQube Plugins
 -------------------
 
-3 technologies are supported by the plugin right now:
+4 technologies are supported by the plugin right now:
 
 - [Java](java-plugin/)
+- [JavaScript](javascript-plugin/)
 - [PHP](php-plugin/)
 - [Python](python-plugin/)
 
@@ -31,7 +32,7 @@ refer to the contribution section.
 
 There is two kind of plugins :
 
-- One for web / backoffice (PHP, Python, Java), using smells described in the 2nd edition of the repository published in
+- One for web / backoffice (PHP, Python, Java, JavaScript), using smells described in the 2nd edition of the repository published in
   september 2015
   You can find all the
   rules [here (in french)](https://docs.google.com/spreadsheets/d/1nujR4EnajnR0NSXjvBW3GytOopDyTfvl3eTk2XGLh5Y/edit#gid=1386834576)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
         source: ./java-plugin/target/ecocode-java-plugin-0.3.0-SNAPSHOT.jar
         target: /opt/sonarqube/extensions/plugins/ecocode-java-plugin-0.3.0-SNAPSHOT.jar
       - type: bind
+        source: ./javascript-plugin/target/ecocode-javascript-plugin-0.3.0-SNAPSHOT.jar
+        target: /opt/sonarqube/extensions/plugins/ecocode-javascript-plugin-0.3.0-SNAPSHOT.jar
+      - type: bind
         source: ./php-plugin/target/ecocode-php-plugin-0.3.0-SNAPSHOT.jar
         target: /opt/sonarqube/extensions/plugins/ecocode-php-plugin-0.3.0-SNAPSHOT.jar
       - type: bind

--- a/javascript-plugin/README.md
+++ b/javascript-plugin/README.md
@@ -1,0 +1,22 @@
+# ecoCode JavaScript plugin
+
+This plugin behaves differently from the others in the ecoCode project. Since version 8.9 of SonarQube, it is no longer
+possible to use an AST to implement a
+rule, [as explained here](https://github.com/SonarSource/sonar-custom-rules-examples/tree/master/javascript-custom-rules).
+In compliance with the SonarSource decision, the ecoCode project uses ESLint to implement the custom rules.
+
+Thus, the plugin does not implement any rules. Its purpose is to import the result of the ESLint analysis of the
+project made with the ecoCode linter, with the complete documentation of each rule. In this context, the rules are
+considered by SonarQube as external: they do not appear in the list of rules but are reported as real rules during the
+analysis ([click to learn more](https://docs.sonarqube.org/latest/analyzing-source-code/importing-external-issues/importing-third-party-issues/)).
+
+🚀 Getting Started
+------------------
+
+The installation is not much more complicated than another ecoCode plugin. In addition to the Sonar plugin, you will
+need to install the ESLint plugin in your JavaScript/TypeScript project to be analyzed:
+
+- Install the SonarQube plugin as described in the [ecoCode README](../README.md#-getting-started).
+- Install the ESLint plugin into your project as described
+  in [ESLint project README](https://github.com/green-code-initiative/ecoCode-linter/blob/main/eslint-plugin/README.md#installation).\
+  This guide also explains how to configure ESLint to import results into SonarQube.

--- a/javascript-plugin/pom.xml
+++ b/javascript-plugin/pom.xml
@@ -63,7 +63,7 @@
                 <artifactId>sonar-packaging-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <pluginKey>${project.artifactId}</pluginKey>
+                    <pluginKey>ecocodejavascript</pluginKey>
                     <pluginName>${project.name}</pluginName>
                     <pluginClass>fr.greencodeinitiative.javascript.JavaScriptPlugin</pluginClass>
                     <sonarLintSupported>true</sonarLintSupported>

--- a/javascript-plugin/pom.xml
+++ b/javascript-plugin/pom.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.ecocode</groupId>
+        <artifactId>ecocode-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>ecocode-javascript-plugin</artifactId>
+    <packaging>sonar-plugin</packaging>
+
+    <name>ecoCode JavaScript Sonar Plugin</name>
+    <description>Provides rules to reduce the environmental footprint of your JavaScript programs</description>
+    <url>https://github.com/green-code-initiative/ecoCode/tree/main/javascript-plugin</url>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.sonarsource.javascript</groupId>
+            <artifactId>sonar-javascript-plugin</artifactId>
+            <type>sonar-plugin</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sonarsource.sonarqube</groupId>
+            <artifactId>sonar-plugin-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sonarsource.sonarqube</groupId>
+            <artifactId>sonar-plugin-api-impl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sonarsource.analyzer-commons</groupId>
+            <artifactId>sonar-analyzer-commons</artifactId>
+        </dependency>
+
+        <!-- Testing dependencies -->
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
+                <artifactId>sonar-packaging-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <pluginKey>${project.artifactId}</pluginKey>
+                    <pluginName>${project.name}</pluginName>
+                    <pluginClass>fr.greencodeinitiative.javascript.JavaScriptPlugin</pluginClass>
+                    <sonarLintSupported>true</sonarLintSupported>
+                    <sonarQubeMinVersion>${sonarqube.version}</sonarQubeMinVersion>
+                    <basePlugin>javascript</basePlugin>
+                    <jreMinVersion>${java.version}</jreMinVersion>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>commons-*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                        <exclude>org/sonar/api/batch/sensor/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>${project.artifactId}</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>../lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <output>file</output>
+                    <append>false</append>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/javascript-plugin/src/main/java/fr/greencodeinitiative/javascript/JavaScriptPlugin.java
+++ b/javascript-plugin/src/main/java/fr/greencodeinitiative/javascript/JavaScriptPlugin.java
@@ -1,0 +1,12 @@
+package fr.greencodeinitiative.javascript;
+
+import org.sonar.api.Plugin;
+
+public class JavaScriptPlugin implements Plugin {
+
+    @Override
+    public void define(Context context) {
+        context.addExtension(JavaScriptRulesDefinition.class);
+    }
+
+}

--- a/javascript-plugin/src/main/java/fr/greencodeinitiative/javascript/JavaScriptRulesDefinition.java
+++ b/javascript-plugin/src/main/java/fr/greencodeinitiative/javascript/JavaScriptRulesDefinition.java
@@ -1,0 +1,19 @@
+package fr.greencodeinitiative.javascript;
+
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonarsource.analyzer.commons.ExternalRuleLoader;
+
+public class JavaScriptRulesDefinition implements RulesDefinition {
+
+    private static final String LANGUAGE = "js";
+    private static final String LINTER_KEY = "eslint_repo";
+    private static final String LINTER_NAME = "ESLint";
+    private static final String METADATA_PATH = "fr/greencodeinitiative/l10n/javascript/rules.json";
+
+    @Override
+    public void define(Context context) {
+        new ExternalRuleLoader(LINTER_KEY, LINTER_NAME, METADATA_PATH, LANGUAGE)
+                .createExternalRuleRepository(context);
+    }
+
+}

--- a/javascript-plugin/src/main/resources/fr/greencodeinitiative/l10n/javascript/rules.json
+++ b/javascript-plugin/src/main/resources/fr/greencodeinitiative/l10n/javascript/rules.json
@@ -1,0 +1,14 @@
+[
+  {
+    "key": "@ecocode/no-multiple-access-dom-element",
+    "type": "CODE_SMELL",
+    "name": "Disallow multiple access of same DOM element",
+    "description": "This rule aims to reduce DOM access assigning its object to variable when access multiple time. It saves CPU cycles.\n<h2>Noncompliant Code Example</h2>\n<pre>\ndocument.getElementById('block1').innerHTML = \"Hello World\";\ndocument.getElementById('block1').style.width = \"50px\";\n</pre>\n<h2>Compliant Solution</h2>\n<pre>\nvar block1 = document.getElementById('block1');\nblock1.innerHTML = \"Hello World\";\nblock1.style.width = \"50px\";\n</pre>\n",
+    "url": "https://github.com/green-code-initiative/ecoCode-linter/blob/main/eslint-plugin/docs/rules/no-multiple-access-dom-element.md",
+    "constantDebtMinutes": 5,
+    "severity": "MINOR",
+    "tags": [
+      "eco-conception"
+    ]
+  }
+]

--- a/javascript-plugin/src/main/resources/fr/greencodeinitiative/l10n/javascript/rules.json
+++ b/javascript-plugin/src/main/resources/fr/greencodeinitiative/l10n/javascript/rules.json
@@ -3,12 +3,11 @@
     "key": "@ecocode/no-multiple-access-dom-element",
     "type": "CODE_SMELL",
     "name": "Disallow multiple access of same DOM element",
-    "description": "This rule aims to reduce DOM access assigning its object to variable when access multiple time. It saves CPU cycles.\n<h2>Noncompliant Code Example</h2>\n<pre>\ndocument.getElementById('block1').innerHTML = \"Hello World\";\ndocument.getElementById('block1').style.width = \"50px\";\n</pre>\n<h2>Compliant Solution</h2>\n<pre>\nvar block1 = document.getElementById('block1');\nblock1.innerHTML = \"Hello World\";\nblock1.style.width = \"50px\";\n</pre>\n",
-    "url": "https://github.com/green-code-initiative/ecoCode-linter/blob/main/eslint-plugin/docs/rules/no-multiple-access-dom-element.md",
+    "description": "\n\n<h2 id=\"rule-details\">Rule details</h2>\n<p>This rule aims to reduce DOM access assigning its object to variable when access multiple time. It saves CPU cycles.</p>\n<h2 id=\"examples\">Examples</h2>\n<p>Examples of <strong>incorrect</strong> code for this rule:</p>\n<pre><code class=\"language-js\">var el1 = document.getElementById(&quot;block1&quot;).test1;\nvar el2 = document.getElementById(&quot;block1&quot;).test2;\n</code></pre>\n<p>Examples of <strong>correct</strong> code for this rule:</p>\n<pre><code class=\"language-js\">var blockElement = document.getElementById(&quot;block1&quot;);\nvar el1 = blockElement.test1;\nvar el2 = blockElement.test2;\n</code></pre>\n<br/><a href=\"https://github.com/green-code-initiative/ecoCode-linter/blob/main/eslint-plugin/docs/rules/no-multiple-access-dom-element.md\">Click here to access the rule details.</a>",
     "constantDebtMinutes": 5,
     "severity": "MINOR",
     "tags": [
-      "eco-conception"
+      "eco-design"
     ]
   }
 ]

--- a/javascript-plugin/src/test/java/fr/greencodeinitiative/javascript/JavaScriptPluginTest.java
+++ b/javascript-plugin/src/test/java/fr/greencodeinitiative/javascript/JavaScriptPluginTest.java
@@ -1,0 +1,41 @@
+package fr.greencodeinitiative.javascript;
+
+import org.junit.Test;
+import org.sonar.api.*;
+import org.sonar.api.utils.Version;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaScriptPluginTest {
+
+    @Test
+    public void extensions() {
+        Plugin.Context context = new Plugin.Context(new MockedSonarRuntime());
+        new JavaScriptPlugin().define(context);
+        assertThat(context.getExtensions()).hasSize(1);
+    }
+
+    private static class MockedSonarRuntime implements SonarRuntime {
+
+        @Override
+        public Version getApiVersion() {
+            return Version.create(9, 9);
+        }
+
+        @Override
+        public SonarProduct getProduct() {
+            return SonarProduct.SONARQUBE;
+        }
+
+        @Override
+        public SonarQubeSide getSonarQubeSide() {
+            return SonarQubeSide.SCANNER;
+        }
+
+        @Override
+        public SonarEdition getEdition() {
+            return SonarEdition.COMMUNITY;
+        }
+    }
+
+}

--- a/javascript-plugin/src/test/java/fr/greencodeinitiative/javascript/JavaScriptRulesDefinitionTest.java
+++ b/javascript-plugin/src/test/java/fr/greencodeinitiative/javascript/JavaScriptRulesDefinitionTest.java
@@ -1,0 +1,22 @@
+package fr.greencodeinitiative.javascript;
+
+import org.junit.Test;
+import org.sonar.api.server.rule.RulesDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaScriptRulesDefinitionTest {
+
+    @Test
+    public void createExternalRepository() {
+        RulesDefinition.Context context = new RulesDefinition.Context();
+        new JavaScriptRulesDefinition().define(context);
+        assertThat(context.repositories()).hasSize(1);
+
+        RulesDefinition.Repository repository = context.repositories().get(0);
+        assertThat(repository.isExternal()).isTrue();
+        assertThat(repository.language()).isEqualTo("js");
+        assertThat(repository.key()).isEqualTo("external_eslint_repo");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <sonar-analyzer-commons.version>2.1.0.1111</sonar-analyzer-commons.version>
         <sonar.python.version>3.19.0.10254</sonar.python.version>
         <sonarphp.version>3.25.0.9077</sonarphp.version>
+        <sonarjavascript.version>9.13.0.20537</sonarjavascript.version>
         <sonar-packaging.version>1.21.0.505</sonar-packaging.version>
         <sonar.skipDependenciesPackaging>true</sonar.skipDependenciesPackaging>
         <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
@@ -96,6 +97,15 @@
                 <artifactId>sonar-java-plugin</artifactId>
                 <type>sonar-plugin</type>
                 <version>${sonarjava.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- JavaScript -->
+            <dependency>
+                <groupId>org.sonarsource.javascript</groupId>
+                <artifactId>sonar-javascript-plugin</artifactId>
+                <type>sonar-plugin</type>
+                <version>${sonarjavascript.version}</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -198,6 +208,7 @@
     <modules>
         <module>python-plugin</module>
         <module>java-plugin</module>
+        <module>javascript-plugin</module>
         <module>php-plugin</module>
     </modules>
 


### PR DESCRIPTION
This plugin does not contain rule-based analysis, as it is not possible to use AST with JavaScript. It only allows to reference the rules driven by the [ESLint plugin of ecoCode-linter](https://github.com/green-code-initiative/ecoCode-linter/tree/main/eslint-plugin). The plugin works in the same way as SonarJS. I plan to develop a tool to import the rules written in the linter to the `rules.json` file of the plugin, it will avoid typo and simplify the process to add a rule.

Note that in this first version, the rules are not referenced in SonarQube directly because they are considered as external. But they do appear in the interface during an analysis, with the detail:

![image](https://user-images.githubusercontent.com/9255967/222958793-9e724b63-495c-4c8d-b003-7b97e5519d78.png)

If you have any ideas to improve the implementation, I'm interested 🤞

---

Useful links to understand this PR: 
- [SonarQube documentation about custom rules by language](https://docs.sonarqube.org/latest/extension-guide/adding-coding-rules/#custom-rule-support-by-language)
- [SonarQube plugin of SonarJS](https://github.com/SonarSource/SonarJS/tree/master/sonar-plugin/sonar-javascript-plugin)
- [Example of external rules in SonarJS](https://github.com/SonarSource/SonarJS/tree/master/sonar-plugin/javascript-checks/src/main/resources/org/sonar/l10n/javascript/rules/eslint)