### PR TITLE
Java - Rules "Avoid returning a JPA Entity in a RestController"

### DIFF
--- a/java-plugin/src/main/java/fr/greencodeinitiative/java/RulesList.java
+++ b/java-plugin/src/main/java/fr/greencodeinitiative/java/RulesList.java
@@ -24,25 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import fr.greencodeinitiative.java.checks.ArrayCopyCheck;
-import fr.greencodeinitiative.java.checks.AvoidConcatenateStringsInLoop;
-import fr.greencodeinitiative.java.checks.AvoidFullSQLRequest;
-import fr.greencodeinitiative.java.checks.AvoidGettingSizeCollectionInLoop;
-import fr.greencodeinitiative.java.checks.AvoidMultipleIfElseStatement;
-import fr.greencodeinitiative.java.checks.AvoidRegexPatternNotStatic;
-import fr.greencodeinitiative.java.checks.AvoidSQLRequestInLoop;
-import fr.greencodeinitiative.java.checks.AvoidSetConstantInBatchUpdate;
-import fr.greencodeinitiative.java.checks.AvoidSpringRepositoryCallInLoopCheck;
-import fr.greencodeinitiative.java.checks.AvoidStatementForDMLQueries;
-import fr.greencodeinitiative.java.checks.AvoidUsageOfStaticCollections;
-import fr.greencodeinitiative.java.checks.AvoidUsingGlobalVariablesCheck;
-import fr.greencodeinitiative.java.checks.FreeResourcesOfAutoCloseableInterface;
-import fr.greencodeinitiative.java.checks.IncrementCheck;
-import fr.greencodeinitiative.java.checks.InitializeBufferWithAppropriateSize;
-import fr.greencodeinitiative.java.checks.NoFunctionCallWhenDeclaringForLoop;
-import fr.greencodeinitiative.java.checks.OptimizeReadFileExceptions;
-import fr.greencodeinitiative.java.checks.UnnecessarilyAssignValuesToVariables;
-import fr.greencodeinitiative.java.checks.UseCorrectForLoop;
+import fr.greencodeinitiative.java.checks.*;
 import org.sonar.plugins.java.api.JavaCheck;
 
 public final class RulesList {
@@ -77,7 +59,8 @@ public final class RulesList {
                 AvoidUsingGlobalVariablesCheck.class,
                 AvoidSetConstantInBatchUpdate.class,
                 FreeResourcesOfAutoCloseableInterface.class,
-                AvoidMultipleIfElseStatement.class
+                AvoidMultipleIfElseStatement.class,
+                AvoidReturningSpringEntityInRestController.class
         ));
     }
 

--- a/java-plugin/src/main/java/fr/greencodeinitiative/java/checks/AvoidReturningSpringEntityInRestController.java
+++ b/java-plugin/src/main/java/fr/greencodeinitiative/java/checks/AvoidReturningSpringEntityInRestController.java
@@ -1,0 +1,64 @@
+package fr.greencodeinitiative.java.checks;
+
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.SymbolMetadata;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Rule(key = "EC7",
+        name = "Developpement",
+        description = AvoidReturningSpringEntityInRestController.RULE_MESSAGE,
+        priority = Priority.MINOR,
+        tags = {"bug"})
+public class AvoidReturningSpringEntityInRestController extends IssuableSubscriptionVisitor {
+
+    protected static final String RULE_MESSAGE = "Avoid returning a JPA Entity in a RestController";
+    private static final String SPRING_REST_CONTROLLER = "org.springframework.web.bind.annotation.RestController";
+    private static final String JPA_ENTITY = "javax.persistence.Entity";
+
+    @Override
+    public List<Tree.Kind> nodesToVisit() {
+        return Arrays.asList(Tree.Kind.CLASS);
+    }
+
+    @Override
+    public void visitNode(Tree tree) {
+        ClassTree classTree = (ClassTree) tree;
+        var annotations = classTree.symbol().metadata().annotations();
+        if (containsAnnotation(annotations, SPRING_REST_CONTROLLER)
+                && hasMethodsReturningJpaEntity(classTree))
+            reportIssue(tree, RULE_MESSAGE);
+    }
+
+    private boolean containsAnnotation(List<SymbolMetadata.AnnotationInstance> annotations,
+                                       String annotationClass) {
+        return annotations != null
+                && !annotations.isEmpty()
+                && annotations.stream().anyMatch(annotation ->
+                annotation.symbol().type().is(annotationClass));
+    }
+
+    private boolean hasMethodsReturningJpaEntity(ClassTree classTree) {
+        List<MethodTree> methods = classTree.members()
+                .stream()
+                .filter(member -> member.is(Tree.Kind.METHOD))
+                .map(MethodTree.class::cast)
+                .filter(method -> method.symbol().isPublic())
+                .collect(Collectors.toList());
+
+        return methods.stream().anyMatch(methodTree -> {
+            var returnType = methods.get(0).returnType().symbolType();
+            var parametrizedTypes = returnType.typeArguments();
+            return Stream.concat(Stream.of(returnType), parametrizedTypes.stream())
+                    .anyMatch(type -> containsAnnotation(type.symbol().metadata().annotations(), JPA_ENTITY));
+        });
+    }
+}

--- a/java-plugin/src/main/java/fr/greencodeinitiative/java/checks/AvoidReturningSpringEntityInRestController.java
+++ b/java-plugin/src/main/java/fr/greencodeinitiative/java/checks/AvoidReturningSpringEntityInRestController.java
@@ -54,7 +54,7 @@ public class AvoidReturningSpringEntityInRestController extends IssuableSubscrip
                 .collect(Collectors.toList());
 
         methods.stream().filter(methodTree -> {
-            var returnType = methods.get(0).returnType().symbolType();
+            var returnType = methodTree.returnType().symbolType();
             var parameterizedTypes = returnType.typeArguments();
             return Stream.concat(Stream.of(returnType), parameterizedTypes.stream())
                     .anyMatch(type -> containsAnnotation(type.symbol().metadata().annotations(), JPA_ENTITY));

--- a/java-plugin/src/main/java/fr/greencodeinitiative/java/checks/AvoidReturningSpringEntityInRestController.java
+++ b/java-plugin/src/main/java/fr/greencodeinitiative/java/checks/AvoidReturningSpringEntityInRestController.java
@@ -55,8 +55,8 @@ public class AvoidReturningSpringEntityInRestController extends IssuableSubscrip
 
         methods.stream().filter(methodTree -> {
             var returnType = methods.get(0).returnType().symbolType();
-            var parametrizedTypes = returnType.typeArguments();
-            return Stream.concat(Stream.of(returnType), parametrizedTypes.stream())
+            var parameterizedTypes = returnType.typeArguments();
+            return Stream.concat(Stream.of(returnType), parameterizedTypes.stream())
                     .anyMatch(type -> containsAnnotation(type.symbol().metadata().annotations(), JPA_ENTITY));
         }).forEach(methodTree -> reportIssue(methodTree.returnType(), RULE_MESSAGE));
     }

--- a/java-plugin/src/main/resources/fr/greencodeinitiative/l10n/java/rules/java/EC7.html
+++ b/java-plugin/src/main/resources/fr/greencodeinitiative/l10n/java/rules/java/EC7.html
@@ -1,0 +1,34 @@
+<p>Using persistence Entity in the return of a Rest controler is not energy efficient.
+    This use induces a multiples unnecessary SQL calls, multiple unused fields serialization, and thus unnecessary calculations by the CPU, RAM usage and network usage.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+@RestController
+public class BookController {
+    private final BookService bookService;
+
+    public BookController(BookService bookstoreService) {
+        this.bookService = bookstoreService;
+    }
+
+    @RequestMapping("books")
+    public List&lt;Book&gt; findBooks() {
+        return bookService.findAll();
+    }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+@RestController
+public class BookController {
+    private final BookService bookService;
+
+    public BookController(BookService bookstoreService) {
+        this.bookService = bookstoreService;
+    }
+
+    @RequestMapping("books")
+    public List&lt;BookDTO&gt; findBooks() {
+        return BookMapper.from(bookService.findAll());
+    }
+}
+</pre>

--- a/java-plugin/src/main/resources/fr/greencodeinitiative/l10n/java/rules/java/EC7.json
+++ b/java-plugin/src/main/resources/fr/greencodeinitiative/l10n/java/rules/java/EC7.json
@@ -1,5 +1,5 @@
 {
-  "title": "Avoid returning persistence Entity in Spring Rest Controller",
+  "title": "Avoid returning a persistence Entity in a Spring RestController",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/java-plugin/src/main/resources/fr/greencodeinitiative/l10n/java/rules/java/EC7.json
+++ b/java-plugin/src/main/resources/fr/greencodeinitiative/l10n/java/rules/java/EC7.json
@@ -1,0 +1,16 @@
+{
+  "title": "Avoid returning persistence Entity in Spring Rest Controller",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "50min"
+  },
+  "tags": [
+    "eco-design",
+    "performance",
+    "bug",
+    "ecocode"
+  ],
+  "defaultSeverity": "Minor"
+}

--- a/java-plugin/src/test/files/AvoidReturningSpringEntityInRestController.java
+++ b/java-plugin/src/test/files/AvoidReturningSpringEntityInRestController.java
@@ -1,0 +1,73 @@
+package fr.greencodeinitiative.java.checks;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.io.Serializable;
+import java.util.List;
+
+@RestController
+public class AvoidReturningSpringEntityInRestController {
+    private final BookService bookService;
+
+    public AvoidReturningSpringEntityInRestController(BookService bookstoreService) {
+        this.bookService = bookstoreService;
+    }
+
+    @RequestMapping("books")
+    public List<Book> findBooks() {
+        return bookService.findAll();
+    }
+
+    @Service
+    public class BookService {
+        private BookRepository bookRepository;
+
+        public BookService(BookRepository bookRepository) {
+            this.bookRepository = bookRepository;
+        }
+
+        public List<Book> findAll() {
+            return bookRepository.findAll();
+        }
+    }
+
+    @Repository
+    public interface BookRepository extends JpaRepository<Book, Integer> {
+    }
+
+    @Entity
+    public class Book implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        private String title;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+    }
+}

--- a/java-plugin/src/test/files/AvoidReturningSpringEntityInRestController.java
+++ b/java-plugin/src/test/files/AvoidReturningSpringEntityInRestController.java
@@ -3,6 +3,7 @@ package fr.greencodeinitiative.java.checks;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,8 +23,13 @@ public class AvoidReturningSpringEntityInRestController {
     }
 
     @RequestMapping("books")
-    public List<Book> findBooks() {
+    public List<Book> findBooks() { // Noncompliant {{Avoid returning a persistence Entity in a Spring RestController}}
         return bookService.findAll();
+    }
+
+    @RequestMapping("books/{id}")
+    public Book findBookById(@PathVariable Long id) { // Noncompliant {{Avoid returning a persistence Entity in a Spring RestController}}
+        return bookService.findById(id);
     }
 
     @Service
@@ -37,10 +43,13 @@ public class AvoidReturningSpringEntityInRestController {
         public List<Book> findAll() {
             return bookRepository.findAll();
         }
+        public Book findById(Long id) {
+            return bookRepository.findById(id).orElse(null);
+        }
     }
 
     @Repository
-    public interface BookRepository extends JpaRepository<Book, Integer> {
+    public interface BookRepository extends JpaRepository<Book, Long> {
     }
 
     @Entity

--- a/java-plugin/src/test/java/fr/greencodeinitiative/java/JavaCheckRegistrarTest.java
+++ b/java-plugin/src/test/java/fr/greencodeinitiative/java/JavaCheckRegistrarTest.java
@@ -32,7 +32,7 @@ class JavaCheckRegistrarTest {
         final JavaCheckRegistrar registrar = new JavaCheckRegistrar();
         registrar.register(context);
 
-        assertThat(context.checkClasses()).hasSize(19);
+        assertThat(context.checkClasses()).hasSize(20);
         assertThat(context.testCheckClasses()).isEmpty();
     }
 }

--- a/java-plugin/src/test/java/fr/greencodeinitiative/java/checks/AvoidReturningSpringEntityInRestControllerTest.java
+++ b/java-plugin/src/test/java/fr/greencodeinitiative/java/checks/AvoidReturningSpringEntityInRestControllerTest.java
@@ -1,0 +1,19 @@
+package fr.greencodeinitiative.java.checks;
+
+import fr.greencodeinitiative.java.utils.FilesUtils;
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+class AvoidReturningSpringEntityInRestControllerTest {
+
+    @Test
+    void test() {
+        CheckVerifier.newVerifier()
+                .onFile("src/test/files/AvoidReturningSpringEntityInRestController.java")
+                .withCheck(new AvoidReturningSpringEntityInRestController())
+                .withClassPath(FilesUtils.getClassPath("target/test-jars"))
+                .verifyIssues();
+    }
+
+
+}


### PR DESCRIPTION
Team : 2 millions

Rule ID incoming (https://github.com/green-code-initiative/ecoCode-challenge/issues/58)

**Rule description** : 
_Using persistence Entity in the return of a Rest controler is not energy efficient.
This use induces a multiples unnecessary SQL calls, multiple unused fields serialization, and thus unnecessary calculations by the CPU, RAM usage and network usage._