### PR TITLE
feat(EC22): Implementing Avoid Method Usage for Only Basic Operations

### DIFF
--- a/java-plugin/src/main/java/fr/greencodeinitiative/java/RulesList.java
+++ b/java-plugin/src/main/java/fr/greencodeinitiative/java/RulesList.java
@@ -24,25 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import fr.greencodeinitiative.java.checks.ArrayCopyCheck;
-import fr.greencodeinitiative.java.checks.AvoidConcatenateStringsInLoop;
-import fr.greencodeinitiative.java.checks.AvoidFullSQLRequest;
-import fr.greencodeinitiative.java.checks.AvoidGettingSizeCollectionInLoop;
-import fr.greencodeinitiative.java.checks.AvoidMultipleIfElseStatement;
-import fr.greencodeinitiative.java.checks.AvoidRegexPatternNotStatic;
-import fr.greencodeinitiative.java.checks.AvoidSQLRequestInLoop;
-import fr.greencodeinitiative.java.checks.AvoidSetConstantInBatchUpdate;
-import fr.greencodeinitiative.java.checks.AvoidSpringRepositoryCallInLoopCheck;
-import fr.greencodeinitiative.java.checks.AvoidStatementForDMLQueries;
-import fr.greencodeinitiative.java.checks.AvoidUsageOfStaticCollections;
-import fr.greencodeinitiative.java.checks.AvoidUsingGlobalVariablesCheck;
-import fr.greencodeinitiative.java.checks.FreeResourcesOfAutoCloseableInterface;
-import fr.greencodeinitiative.java.checks.IncrementCheck;
-import fr.greencodeinitiative.java.checks.InitializeBufferWithAppropriateSize;
-import fr.greencodeinitiative.java.checks.NoFunctionCallWhenDeclaringForLoop;
-import fr.greencodeinitiative.java.checks.OptimizeReadFileExceptions;
-import fr.greencodeinitiative.java.checks.UnnecessarilyAssignValuesToVariables;
-import fr.greencodeinitiative.java.checks.UseCorrectForLoop;
+import fr.greencodeinitiative.java.checks.*;
 import org.sonar.plugins.java.api.JavaCheck;
 
 public final class RulesList {
@@ -77,7 +59,8 @@ public final class RulesList {
                 AvoidUsingGlobalVariablesCheck.class,
                 AvoidSetConstantInBatchUpdate.class,
                 FreeResourcesOfAutoCloseableInterface.class,
-                AvoidMultipleIfElseStatement.class
+                AvoidMultipleIfElseStatement.class,
+                AvoidMethodUsageForOnlyBasicOperations.class
         ));
     }
 

--- a/java-plugin/src/main/java/fr/greencodeinitiative/java/checks/AvoidMethodUsageForOnlyBasicOperations.java
+++ b/java-plugin/src/main/java/fr/greencodeinitiative/java/checks/AvoidMethodUsageForOnlyBasicOperations.java
@@ -1,0 +1,52 @@
+package fr.greencodeinitiative.java.checks;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static fr.greencodeinitiative.java.checks.AvoidMethodUsageForOnlyBasicOperations.RULE_MESSAGE;
+import static org.sonar.check.Priority.MINOR;
+
+/**
+ * @author Mohamed Oussama A.
+ * Created on 05/04/2023
+ * @version 1.0
+ */
+
+@Rule(key = "EC22",
+        name = RULE_MESSAGE,
+        description = RULE_MESSAGE,
+        priority = MINOR,
+        tags = {"smell", "ecocode", "eco-design", "memory", "performance"})
+public class AvoidMethodUsageForOnlyBasicOperations extends IssuableSubscriptionVisitor {
+
+    protected static final String RULE_MESSAGE = "Avoid Method Usage For Only Basic Operations";
+
+    @Override
+    public List<Tree.Kind> nodesToVisit() {
+        return Collections.singletonList(Tree.Kind.METHOD);
+    }
+
+
+    @Override
+    public void visitNode(Tree tree) {
+        Optional.ofNullable(((MethodTree) tree).block())
+                .map(BlockTree::body)
+                .filter(list -> list.size() == 1)
+                .flatMap(list -> list.stream().findFirst())
+                .filter(ReturnStatementTree.class::isInstance)
+                .map(statementTree -> ((ReturnStatementTree) statementTree).expression())
+                .filter(this.isBasicOperation)
+                .ifPresent(expressionTree -> reportIssue(expressionTree, RULE_MESSAGE));
+    }
+
+
+    private Predicate<ExpressionTree> isBasicOperation = expression -> expression instanceof BinaryExpressionTree
+            || expression instanceof UnaryExpressionTree
+            || expression.is(Tree.Kind.CONDITIONAL_EXPRESSION);
+}

--- a/java-plugin/src/main/resources/fr/greencodeinitiative/l10n/java/rules/java/EC22.html
+++ b/java-plugin/src/main/resources/fr/greencodeinitiative/l10n/java/rules/java/EC22.html
@@ -1,0 +1,13 @@
+<p>we should not use methods for only basic operations</p>
+<h2>Non compliant Code Example</h2>
+<pre>
+    public int sum(int a, int b) {
+        return a + b; // Noncompliant
+    }
+
+    x = sum(5, 4); // Noncompliant
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+    x = a + b;
+</pre>

--- a/java-plugin/src/main/resources/fr/greencodeinitiative/l10n/java/rules/java/EC22.json
+++ b/java-plugin/src/main/resources/fr/greencodeinitiative/l10n/java/rules/java/EC22.json
@@ -1,0 +1,16 @@
+{
+  "title": "we should not use methods for only basic operations",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "eco-design",
+    "memory",
+    "performance",
+    "ecocode"
+  ],
+  "defaultSeverity": "Minor"
+}

--- a/java-plugin/src/test/files/AvoidMethodUsageForOnlyBasicOperations.java
+++ b/java-plugin/src/test/files/AvoidMethodUsageForOnlyBasicOperations.java
@@ -1,0 +1,143 @@
+/**
+ * @author Mohamed Oussama A.
+ * Created on 05/04/2023
+ * @version 1.0
+ */
+public class AvoidBasicOperationsUsageMethods {
+
+    private int x =0;
+
+    /*
+    * Below method must be reported by an other Rule of unnecessarily assignment of variable
+    * (but not with this rule - SRP - SOLID )
+    * */
+
+    public static int getMin(int a, int b) {
+        int c = a < b ? a : b; // Compliant
+        return c;
+    }
+
+    public int getX() {
+        return x; // Compliant
+    }
+
+    /*
+     * Conditional expressions using ternanry operator
+     */
+    public static int getMin(int a, int b) {
+        return a < b ? a : b; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int calculateFormuleX(int a, int b) {
+        return a / a * b < b ? a - b : b + a; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    /*
+     * Binary Operations
+     */
+
+    //Using Arithmetic Operators
+
+    public static int add(int a, int b) {
+        return a + b; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int substract(int a, int b) {
+        return a - b; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int multiply(int a, int b) {
+        return a * b; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int divide(int a, int b) {
+        return a / b; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int modulus(int a, int b) {
+        return a % b; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    //Using Logical Operators
+
+    public static boolean compareAnd(int a, int b) {
+        return (a > b) && (b > 0); // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static boolean compareOr(int a, int b) {
+        return (a > b) || (b > 0); // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static boolean equalsTo(int a, int b) {
+        return a == b; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static boolean notEqualsTo(int a, int b) {
+        return !(a == b); // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static boolean compare1(int a, int b) {
+        return (a > b) && (b > 0); // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    // Using Bitwise operators
+
+    public static boolean andBitwise(int a, int b) {
+        return a & b; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static boolean orBitwise(int a, int b) {
+        return a | b; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static boolean xorBitwise(int a, int b) {
+        return a ^ b; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    /*
+     * Unary Operations
+     */
+
+    public static int negate(int a) {
+        return -a; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int preIncrement(int a) {
+        return ++a; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int postDecrement(int a) {
+        return a--; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int notBitwise(int a) {
+        return ~a; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    // Using Bitwise operators
+
+    public static int negate(int a) {
+        return -a; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int preIncrement(int a) {
+        return ++a; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int postDecrement(int a) {
+        return a--; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int leftShift(int a) {
+        return a << 1; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int rightShift(int a) {
+        return a >> 1; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+    public static int zeroFillRightShift(int a) {
+        return a >>> 1; // Noncompliant {{Avoid Method Usage For Only Basic Operations}}
+    }
+
+}

--- a/java-plugin/src/test/java/fr/greencodeinitiative/java/JavaCheckRegistrarTest.java
+++ b/java-plugin/src/test/java/fr/greencodeinitiative/java/JavaCheckRegistrarTest.java
@@ -32,7 +32,7 @@ class JavaCheckRegistrarTest {
         final JavaCheckRegistrar registrar = new JavaCheckRegistrar();
         registrar.register(context);
 
-        assertThat(context.checkClasses()).hasSize(19);
+        assertThat(context.checkClasses()).hasSize(20);
         assertThat(context.testCheckClasses()).isEmpty();
     }
 }

--- a/java-plugin/src/test/java/fr/greencodeinitiative/java/checks/AvoidMethodUsageForOnlyBasicOperationsTest.java
+++ b/java-plugin/src/test/java/fr/greencodeinitiative/java/checks/AvoidMethodUsageForOnlyBasicOperationsTest.java
@@ -1,0 +1,20 @@
+package fr.greencodeinitiative.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+/**
+ * @author Mohamed Oussama ABIDI.
+ * Created on 05/04/2023
+ * @version 1.0
+ */
+class AvoidMethodUsageForOnlyBasicOperationsTest {
+
+    @Test
+    void it_should_verify_non_compliant_basic_operations_usage_in_methods() {
+        CheckVerifier.newVerifier()
+                .onFile("src/test/files/AvoidMethodUsageForOnlyBasicOperations.java")
+                .withCheck(new AvoidMethodUsageForOnlyBasicOperations())
+                .verifyIssues();
+    }
+}


### PR DESCRIPTION
### Description : <br>
Using methods for basic operations consumes additional system resources. 
The interpreter must in effect and solve the objects and then the methods, just to carry out these simple operations of the language.

### Implementation 

1. **What's a basic operation**  in Java?
 A "**basic operation**" involve the use of arithmetic, comparison, and logical operators.  <br>
These operators are used either in **Binary expression** or **Unary expression**  and also in **Conditional exprssion** using ternary operator.
<br>So **technically**, using Java Sonar's API, an expression which is instance of **BinaryExpressionTree** or **UnaryExpressionTree** or  is **Tree.Kind.CONDITIONAL_EXPRESSION** => represents a basic operation !


2. **What kind of methods should be targeted** ?
Each method having a return statement of a basic operation

3. **What this Rule do not cover ?**
The below example of code contains an assignment ecpression then a return statement  : 
```
public int add(int a, int b) {
  int c = a+b;
  return c;
}
```
As there is an **unnecessarily assignement** , it should be reported by another Rule.<br>
So respecting **Single Resp. Principle** of SOLID and regarding the scope of EC22 this practice wont be reported despite the presence of a basic operation.

Same case could be detected with **mutation**.


![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/56519263/230372499-c10bab91-048e-4aa7-9eb3-14b5e6414c64.png)
![MicrosoftTeams-image](https://user-images.githubusercontent.com/56519263/230372521-e3f1c3e5-c14d-42f6-bc15-b5ac7abd06e5.png)

