### PR TITLE
green-code-initiative/ecoCode#63 fix: fixes SonarSource/sonar-update-center-properties metadata generation

### DIFF
--- a/java-plugin/pom.xml
+++ b/java-plugin/pom.xml
@@ -44,12 +44,6 @@
             <version>3.11</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
-        </dependency>
-
         <!-- for security on regex patterns : https://github.com/google/re2j -->
         <dependency>
             <groupId>com.google.re2j</groupId>
@@ -89,10 +83,6 @@
                     <pluginClass>fr.greencodeinitiative.java.JavaPlugin</pluginClass>
                     <sonarLintSupported>true</sonarLintSupported>
                     <sonarQubeMinVersion>${sonarqube.version}</sonarQubeMinVersion>
-                    <!-- TODO : commented because plugin not loaded in SONAR if required version of java plugin is not installed -->
-                    <!-- TODO : check how to resolve it (how to force this version in SonarQube installation) -->
-                    <!-- <requirePlugins>java:${sonarjava.version}</requirePlugins> -->
-                    <basePlugin>java</basePlugin>
                     <jreMinVersion>${java.version}</jreMinVersion>
                 </configuration>
             </plugin>

--- a/javascript-plugin/pom.xml
+++ b/javascript-plugin/pom.xml
@@ -64,7 +64,6 @@
                     <pluginClass>fr.greencodeinitiative.javascript.JavaScriptPlugin</pluginClass>
                     <sonarLintSupported>true</sonarLintSupported>
                     <sonarQubeMinVersion>${sonarqube.version}</sonarQubeMinVersion>
-                    <basePlugin>javascript</basePlugin>
                     <jreMinVersion>${java.version}</jreMinVersion>
                 </configuration>
             </plugin>

--- a/php-plugin/pom.xml
+++ b/php-plugin/pom.xml
@@ -59,9 +59,7 @@
                     <pluginClass>fr.greencodeinitiative.php.PHPPlugin</pluginClass>
                     <sonarLintSupported>true</sonarLintSupported>
                     <sonarQubeMinVersion>${sonarqube.version}</sonarQubeMinVersion>
-                    <basePlugin>php</basePlugin>
                     <jreMinVersion>${java.version}</jreMinVersion>
-                    <requirePlugins>php:${sonarphp.version}</requirePlugins>
                     <sonarQubeMinVersion>${sonarqube.version}</sonarQubeMinVersion>
                     <jreMinVersion>${java.version}</jreMinVersion>
                 </configuration>

--- a/php-plugin/src/main/java/fr/greencodeinitiative/php/PhpRuleRepository.java
+++ b/php-plugin/src/main/java/fr/greencodeinitiative/php/PhpRuleRepository.java
@@ -24,12 +24,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableList;
 import fr.greencodeinitiative.php.checks.AvoidDoubleQuoteCheck;
 import fr.greencodeinitiative.php.checks.AvoidFullSQLRequestCheck;
 import fr.greencodeinitiative.php.checks.AvoidSQLRequestInLoopCheck;
@@ -90,7 +88,7 @@ public class PhpRuleRepository implements RulesDefinition, PHPCustomRuleReposito
 
   @Override
   public List<Class<?>> checkClasses() {
-    return ImmutableList.of(
+    return List.of(
             AvoidDoubleQuoteCheck.class,
             AvoidFullSQLRequestCheck.class,
             AvoidSQLRequestInLoopCheck.class,

--- a/python-plugin/pom.xml
+++ b/python-plugin/pom.xml
@@ -57,7 +57,6 @@
                     <pluginName>${project.name}</pluginName>
                     <pluginClass>fr.greencodeinitiative.python.PythonPlugin</pluginClass>
                     <sonarLintSupported>true</sonarLintSupported>
-                    <requirePlugins>python:${sonarpython.version}</requirePlugins>
                     <sonarQubeMinVersion>${sonarqube.version}</sonarQubeMinVersion>
                     <jreMinVersion>${java.version}</jreMinVersion>
                 </configuration>


### PR DESCRIPTION
Since "core" analyzers (ex: Java, C#, JavaScript, TypeScript, CloudFormation, Terraform, Docker, Kubernetes, Kotlin, Ruby, Go, Scala, Flex, Python, PHP, HTML, CSS, XML and VB.NET) have been integrated more tightly with SonarQube, they no longer appear on the Marketplace. So now (Java, PHP, Python, javaScript) ecoCode plugins should no longer explicitly "require" their respective language "core" analyzers.

More information: https://community.sonarsource.com/t/new-plugin-ecocode-requesting-inclusion-in-sonarqube-marketplace/85398/20