### PR TITLE
Allow creation of language-specific metadata files

### DIFF
--- a/ecocode-rules-specifications/README.md
+++ b/ecocode-rules-specifications/README.md
@@ -1,15 +1,45 @@
 # ecoCode rules specification repository
 
-## Description
+This project contains the specifications of all ecoCode rules, for all languages.
 
-This project contains the specifications of the ecoCode rules.
+## Structure
 
-All the existing rules can be found in the [rules folder](src/main/rules).
+Rules are organized by folder based on their ID in the [root rules folder](src/main/rules).
+Each of these folders contains a file with the metadata of the rule, and description by language.
+
+The metadata file uses the format supported by
+the [SonarSource Analyzers Commons](https://github.com/SonarSource/sonar-analyzer-commons/tree/master/commons) library.
+To find out what values can be put there, we advise you to use the
+official [SonarQube documentation](https://docs.sonarsource.com/sonarqube/latest/user-guide/rules/overview/), and to
+rely on already existing files.
+
+Here is an example:
+
+```text
+src/main/rules
+├── EC104
+│   ├── java
+│   │   ├── EC104.asciidoc
+│   │   ├── EC104.json
+│   ├── php
+│   │   ├── EC104.asciidoc
+│   ├── python
+│   │   ├── EC104.asciidoc
+│   └── EC104.json
+├── ...
+```
+
+To specify metadata for a given language (for example deprecate a rule only for a single language), it is possible to
+create a json file in the language folder, and this will be merged with the common file during build. The keys in the
+specific file have priority and it is possible to add new ones but not to delete them from the global one.
 
 ## Description language
 
-The description of the rules uses the ASCIIDOC format (with [Markdown compatibility](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#markdown-compatibility)) in order to allow the inclusion of other pages (this feature is not available in standard with Markdown).
+The description of the rules uses the ASCIIDOC format (
+with [Markdown compatibility](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#markdown-compatibility))
+in order to allow the inclusion of other pages (this feature is not available in standard with Markdown).
 
 See:
+
 * [AsciiDoc Syntax Quick Reference](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/)
 * [Compare AsciiDoc to Markdown](https://docs.asciidoctor.org/asciidoc/latest/asciidoc-vs-markdown/)

--- a/ecocode-rules-specifications/pom.xml
+++ b/ecocode-rules-specifications/pom.xml
@@ -14,21 +14,6 @@
 	<description>Repository that contains the specifications of every static-analysis rules available in ecoCode plugins.</description>
 	<url>https://github.com/green-code-initiative/ecoCode/tree/main/ecocode-rules-specifications</url>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.googlecode.json-simple</groupId>
-			<artifactId>json-simple</artifactId>
-			<version>1.1.1</version>
-			<optional>true</optional> <!-- Do not expose this dependency to children -->
-			<exclusions>
-				<exclusion>
-					<groupId>*</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin><!--
@@ -98,6 +83,21 @@
 						</configuration>
 					</execution>
 				</executions>
+
+				<dependencies>
+					<dependency>
+						<groupId>jakarta.json</groupId>
+						<artifactId>jakarta.json-api</artifactId>
+						<version>2.1.2</version>
+					</dependency>
+
+					<dependency>
+						<groupId>org.glassfish</groupId>
+						<artifactId>jakarta.json</artifactId>
+						<version>2.0.1</version>
+						<classifier>module</classifier>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<plugin><!--
 					This module produce one artifact by language (with corresponding classifier)

--- a/ecocode-rules-specifications/pom.xml
+++ b/ecocode-rules-specifications/pom.xml
@@ -14,6 +14,21 @@
 	<description>Repository that contains the specifications of every static-analysis rules available in ecoCode plugins.</description>
 	<url>https://github.com/green-code-initiative/ecoCode/tree/main/ecocode-rules-specifications</url>
 
+	<dependencies>
+		<dependency>
+			<groupId>com.googlecode.json-simple</groupId>
+			<artifactId>json-simple</artifactId>
+			<version>1.1.1</version>
+			<optional>true</optional> <!-- Do not expose this dependency to children -->
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin><!--

--- a/ecocode-rules-specifications/src/main/script/PrepareResources.jsh
+++ b/ecocode-rules-specifications/src/main/script/PrepareResources.jsh
@@ -1,8 +1,12 @@
 //usr/bin/env jshell -v "$@" "$0"; exit $?
 
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
+
+import jakarta.json.Json;
+import jakarta.json.JsonMergePatch;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+import jakarta.json.JsonWriter;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -26,7 +30,7 @@ import static java.util.Optional.of;
         private final Path sourceDir;
         private final Path targetDir;
 
-        public static void main(String... args) throws Exception {
+        public static void main(String... args) {
             new PrepareResources(
                     Path.of(Objects.requireNonNull(System.getProperty("sourceDir"), "system property: sourceDir")),
                     Path.of(Objects.requireNonNull(System.getProperty("targetDir"), "system property: targetDir"))
@@ -41,7 +45,7 @@ import static java.util.Optional.of;
         @Override
         public void run() {
             getResourcesToCopy().forEach(rule -> {
-                mergeAndCopyFile(rule.metadata, rule.specificMetadata, rule.getMetadataTargetPath(targetDir));
+                mergeAndCopyJsonMetadata(rule.metadata, rule.specificMetadata, rule.getMetadataTargetPath(targetDir));
                 copyFile(rule.htmlDescription, rule.getHtmlDescriptionTargetPath(targetDir));
             });
         }
@@ -59,38 +63,30 @@ import static java.util.Optional.of;
             }
         }
 
-        private void mergeAndCopyFile(Path source, Path merge, Path target) {
+        private void mergeAndCopyJsonMetadata(Path source, Path merge, Path target) {
             if (Files.isRegularFile(merge)) {
                 LOGGER.log(DEBUG, "Merge: {0} and {1} -> {2}", source, merge, target);
+
                 try (
-                    FileReader sourceReader = new FileReader(source.toFile());
-                    FileReader mergeReader = new FileReader(merge.toFile())
+                    JsonReader sourceJsonReader = Json.createReader(Files.newBufferedReader(source));
+                    JsonReader mergeJsonReader = Json.createReader(Files.newBufferedReader(merge));
+                    JsonWriter resultJsonWriter = Json.createWriter(Files.newBufferedWriter(target));
                 ) {
-                    JSONParser parser = new JSONParser();
-                    JSONObject sourceJson = (JSONObject) parser.parse(sourceReader);
-                    JSONObject mergeJson = (JSONObject) parser.parse(mergeReader);
-
-                    mergeJsonObjects(sourceJson, mergeJson);
-
                     Files.createDirectories(target.getParent());
-                    Files.write(target, sourceJson.toString().getBytes());
-                } catch (IOException | ParseException e) {
+
+                    JsonObject sourceJson = sourceJsonReader.readObject();
+                    JsonObject mergeJson = mergeJsonReader.readObject();
+
+                    JsonMergePatch mergePatch = Json.createMergePatch(mergeJson);
+                    JsonValue result = mergePatch.apply(sourceJson);
+
+                    resultJsonWriter.write(result);
+                } catch (IOException e) {
                     throw new RuntimeException("cannot process source " + source, e);
                 }
             } else {
                 copyFile(source, target);
             }
-        }
-
-        private void mergeJsonObjects(JSONObject object1, JSONObject object2) {
-            object2.forEach((key, value) -> {
-                Object element = object1.get(key);
-                if (element instanceof JSONObject && value instanceof JSONObject) {
-                    mergeJsonObjects((JSONObject) element, (JSONObject) value);
-                } else {
-                    object1.put(key, value);
-                }
-            });
         }
 
         private void copyFile(Path source, Path target) {


### PR DESCRIPTION
This PR adds the ability to create language-specific metadata files (an idea discussed during previous weekly meeting).
The main objective is to precise some informations about a rule for a specific language.

Let's take an example. If I want to deprecate EC4 but only for Java language, I can create the file `src/main/rules/EC4/java/EC4.json` with the following content.

```json
{
  "status": "deprecated"
}
```

This json file **will be merged** during build with the one in the rule root folder. So the result for java/EC4 in the built jar will be:

```json
{
  "title": "Avoid using global variables",
  "type": "CODE_SMELL",
  "status": "deprecated",
  "remediation": {
    "func": "Constant\/Issue",
    "constantCost": "5min"
  },
  "tags": [
    "performance",
    "eco-design",
    "ecocode"
  ],
  "defaultSeverity": "Minor"
}
```

The script also allows to create new JSON keys for a specific language (if we want to add a description or something else).