### PR TITLE
[ISSUE 185] plugins SHA1 null when starting SONARQUBE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#128](https://github.com/green-code-initiative/ecoCode/pull/128) Adding EC35 rule for Python and PHP : EC35 rule replaces EC34 with a specific use case ("file not found" sepcific)
 - [#132](https://github.com/green-code-initiative/ecoCode/issues/132) Upgrade RULES.md: set proposed Python rule "Use numpy array instead of standard list" as refused with link to the justification
 - [#103](https://github.com/green-code-initiative/ecoCode/issues/103) Upgrade RULES.md: set proposed HTML rule "HTML page must contain a doctype tag" as refused with link to the justification
+- [#185](https://github.com/green-code-initiative/ecoCode/issues/185) Add build number to manifest
 
 ### Deleted
 

--- a/java-plugin/pom.xml
+++ b/java-plugin/pom.xml
@@ -89,17 +89,39 @@
                 <extensions>true</extensions>
                 <configuration>
                     <pluginKey>ecocodejava</pluginKey>
-                    <pluginName>${project.name}</pluginName>
                     <pluginClass>fr.greencodeinitiative.java.JavaPlugin</pluginClass>
                     <sonarLintSupported>true</sonarLintSupported>
-                    <sonarQubeMinVersion>${sonarqube.version}</sonarQubeMinVersion>
+                    <pluginApiMinVersion>${sonarqube.version}</pluginApiMinVersion>
                     <jreMinVersion>${java.version}</jreMinVersion>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Build>${buildNumber}</Implementation-Build>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>
                 <!-- shade plugin configuration is on parent pom.xml because of use for other modules -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <!-- plugin to generate a unique build number for sonar-packaging-maven-plugin : usage of buildNumber variable -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                    <revisionOnScmFailure>0</revisionOnScmFailure>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 
         <sonar-analyzer-commons.version>2.5.0.1358</sonar-analyzer-commons.version>
 
-        <sonar-packaging.version>1.21.0.505</sonar-packaging.version>
+        <sonar-packaging.version>1.23.0.740</sonar-packaging.version>
         <sonar.skipDependenciesPackaging>true</sonar.skipDependenciesPackaging>
 
         <junit.jupiter.version>5.9.1</junit.jupiter.version>


### PR DESCRIPTION
upgrade based on https://github.com/green-code-initiative/ecoCode-javascript/commit/3d14679e184dc319f1a9fcaf6c4eb359528b4bd7

- pom.xml upgrade to make the correction
- upgrade sonar-packaging configuration and version