### PR TITLE
[EC81] [C#] Fix type in json spec to allow import into Sonarqube

### DIFF
--- a/ecocode-rules-specifications/src/main/rules/EC81/EC81.json
+++ b/ecocode-rules-specifications/src/main/rules/EC81/EC81.json
@@ -1,6 +1,6 @@
 {
   "title": "Specify struct layout",
-  "type": "PERFORMANCE",
+  "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",


### PR DESCRIPTION
We need to update type specified in EC81 json spec to 'CODE_SMELL' as initial value (i.e. 'PERFORMANCE') is rejected by Sonarqube.

This fix is mandatory to be able to produce the first release of our C# SQ plugin.