### PR TITLE
Added Swift version for EC528

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [#313](https://github.com/green-code-initiative/ecoCode/issues/313) [EC528] Swift port
+
 
 ### Changed
 

--- a/ecocode-rules-specifications/src/main/rules/EC528/swift/EC528.asciidoc
+++ b/ecocode-rules-specifications/src/main/rules/EC528/swift/EC528.asciidoc
@@ -1,0 +1,13 @@
+Shaking or vibrating an iOS device is possible using `UIFeedbackGenerator`.
+Behind this effect stands a specific hardware component, the Taptic Engine, which consumes power. As a consequence, its usage should be carefully considered, especially if its added value is not clear.
+
+## Noncompliant Code Example
+
+```swift
+import UIKit
+
+func triggerVibration() {
+    let generator = UIImpactFeedbackGenerator(style: .heavy)
+    generator.impactOccurred()
+}
+```


### PR DESCRIPTION
A port of EC528 rule.
This rule already exists for Android / Java.

Addresses issue https://github.com/green-code-initiative/ecoCode/issues/313