### PR TITLE
feat: #449 use language-specific entries in Maven build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,11 +71,11 @@ jobs:
           if [ -f target/classes/rules.json ]; then
             mkdir -p deployment
             cp target/classes/rules.json deployment/rules.json
-            # Copy HTML files organized by technology
-            for tech_dir in target/classes/org/green-code-initiative/rules/*/; do
-              tech_name=$(basename "$tech_dir")
-              mkdir -p "deployment/$tech_name"
-              cp "$tech_dir"*.html "deployment/$tech_name/" 2>/dev/null || true
+            # Copy HTML files organized by language
+            for lang_dir in target/classes/org/green-code-initiative/rules/*/; do
+              lang_name=$(basename "$lang_dir")
+              mkdir -p "deployment/$lang_name"
+              cp "$lang_dir"*.html "deployment/$lang_name/" 2>/dev/null || true
             done
             echo "ready=true" >> $GITHUB_OUTPUT
           else

--- a/maven-build/README.md
+++ b/maven-build/README.md
@@ -17,12 +17,18 @@ When index.json export is enabled, the generated file has the following structur
       "id": "GCI1",
       "name": "Rule Title",
       "severity": "MAJOR",
-      "technologies": ["java", "javascript"],
-      "status": "READY"
+      "languages": {
+        "java": {
+          "status": "READY"
+        },
+        "javascript": {
+          "status": "DEPRECATED"
+        }
+      }
     }
   ],
   "meta": {
-    "technologies": ["java", "javascript", "python"],
+    "languages": { "java": "Java", "javascript": "JS/TS" },
     "severities": ["CRITICAL", "INFO", "MAJOR", "MINOR"],
     "statuses": ["DEPRECATED", "READY"]
   }
@@ -34,11 +40,13 @@ When index.json export is enabled, the generated file has the following structur
 This module follows **Domain-Driven Design (DDD)** principles:
 
 ### Domain Layer
+
 - **Pure domain models** with no external dependencies
 - Business logic and rules validation
 - Technology-agnostic
 
 ### Infrastructure Layer
+
 - File system operations
 - JSON parsing and writing
 - External dependencies (Jakarta JSON, NIO)

--- a/maven-build/main/java/org/greencodeinitiative/mavenbuild/ruleexporter/domain/RuleDescriptionFile.java
+++ b/maven-build/main/java/org/greencodeinitiative/mavenbuild/ruleexporter/domain/RuleDescriptionFile.java
@@ -31,12 +31,12 @@ public class RuleDescriptionFile {
 
     private final Path path;
     private final RuleKey ruleKey;
-    private final String technology;
+    private final String language;
 
-    public RuleDescriptionFile(String path, String key, String technology) {
+    public RuleDescriptionFile(String path, String key, String language) {
         this.path = Path.of(path);
         this.ruleKey = new RuleKey(key);
-        this.technology = technology;
+        this.language = language;
     }
 
     public Path getPath() {
@@ -51,8 +51,8 @@ public class RuleDescriptionFile {
         return ruleKey + ".json";
     }
 
-    public String getTechnology() {
-        return technology;
+    public String getLanguage() {
+        return language;
     }
 
     public Path getMetadataPath() {
@@ -64,10 +64,10 @@ public class RuleDescriptionFile {
     }
 
     public Path getHtmlDescriptionTargetPath(Path targetDir) {
-        return targetDir.resolve(technology).resolve(ruleKey + ".html");
+        return targetDir.resolve(language).resolve(ruleKey + ".html");
     }
 
     public Path getMetadataTargetPath(Path targetDir) {
-        return targetDir.resolve(technology).resolve(getMetadataFileName());
+        return targetDir.resolve(language).resolve(getMetadataFileName());
     }
 }

--- a/maven-build/main/java/org/greencodeinitiative/mavenbuild/ruleexporter/domain/RuleMetadata.java
+++ b/maven-build/main/java/org/greencodeinitiative/mavenbuild/ruleexporter/domain/RuleMetadata.java
@@ -3,14 +3,14 @@ package org.greencodeinitiative.mavenbuild.ruleexporter.domain;
 public class RuleMetadata {
 
     private final RuleKey key;
-    private final String technology;
+    private final String language;
     private final String title;
     private final RuleSeverity severity;
     private final RuleStatus status;
 
-    private RuleMetadata(RuleKey key, String technology, String title, RuleSeverity severity, RuleStatus status) {
+    private RuleMetadata(RuleKey key, String language, String title, RuleSeverity severity, RuleStatus status) {
         this.key = key;
-        this.technology = technology;
+        this.language = language;
         this.title = title;
         this.severity = severity;
         this.status = status;
@@ -20,8 +20,8 @@ public class RuleMetadata {
         return this.key;
     }
 
-    public String getTechnology() {
-        return this.technology;
+    public String getLanguage() {
+        return this.language;
     }
 
     public String getTitle() {
@@ -39,28 +39,28 @@ public class RuleMetadata {
     @Override
     public String toString() {
         return (
-                "RuleMetadata{" +
-                        "key='" +
-                        key +
-                        '\'' +
-                        ", language='" +
-                        technology +
-                        '\'' +
-                        ", title='" +
-                        title +
-                        '\'' +
-                        ", severity=" +
-                        severity +
-                        ", status=" +
-                        status +
-                        '}'
+            "RuleMetadata{" +
+                    "key='" +
+                    key +
+                    '\'' +
+                    ", language='" +
+                    language +
+                    '\'' +
+                    ", title='" +
+                    title +
+                    '\'' +
+                    ", severity=" +
+                    severity +
+                    ", status=" +
+                    status +
+                    '}'
         );
     }
 
     public static class Builder {
 
         private RuleKey key;
-        private String technology;
+        private String language;
         private String title;
         private RuleSeverity severity;
         private RuleStatus status;
@@ -70,8 +70,8 @@ public class RuleMetadata {
             return this;
         }
 
-        public Builder technology(String technology) {
-            this.technology = technology;
+        public Builder language(String language) {
+            this.language = language;
             return this;
         }
 
@@ -91,7 +91,7 @@ public class RuleMetadata {
         }
 
         public RuleMetadata build() {
-            return new RuleMetadata(key, technology, title, severity, status);
+            return new RuleMetadata(key, language, title, severity, status);
         }
     }
 }

--- a/maven-build/main/java/org/greencodeinitiative/mavenbuild/ruleexporter/infra/ConfigLoader.java
+++ b/maven-build/main/java/org/greencodeinitiative/mavenbuild/ruleexporter/infra/ConfigLoader.java
@@ -30,16 +30,15 @@ public class ConfigLoader {
         }
     }
 
-    public static Map<String, String> getTechnologyLabels() {
+    public static Map<String, String> getLanguageLabels() {
         Map<String, String> labels = new HashMap<>();
-        if (config.containsKey("technologies")) {
-            JsonObject technologies = config.getJsonObject("technologies");
-            for (String key : technologies.keySet()) {
-                labels.put(key, technologies.getString(key));
+        if (config.containsKey("languages")) {
+            JsonObject languages = config.getJsonObject("languages");
+            for (String key : languages.keySet()) {
+                labels.put(key, languages.getString(key));
             }
         }
         return labels;
     }
 
 }
-

--- a/maven-build/main/java/org/greencodeinitiative/mavenbuild/ruleexporter/infra/RuleFactory.java
+++ b/maven-build/main/java/org/greencodeinitiative/mavenbuild/ruleexporter/infra/RuleFactory.java
@@ -42,7 +42,7 @@ public class RuleFactory {
 
             return new RuleMetadata.Builder()
                     .key(ruleFile.getRuleKey())
-                    .technology(ruleFile.getTechnology())
+                    .language(ruleFile.getLanguage())
                     .title(jsonObject.getString("title"))
                     .severity(severity)
                     .status(status)

--- a/maven-build/main/java/org/greencodeinitiative/mavenbuild/ruleexporter/infra/RuleMetadataWriter.java
+++ b/maven-build/main/java/org/greencodeinitiative/mavenbuild/ruleexporter/infra/RuleMetadataWriter.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -19,11 +20,11 @@ import java.util.stream.Collectors;
 public class RuleMetadataWriter {
 
     private final String outputFilename;
-    private final Map<String, String> technologyLabels;
+    private final Map<String, String> languageLabels;
 
     public RuleMetadataWriter(String outputFilename) {
         this.outputFilename = outputFilename;
-        this.technologyLabels = ConfigLoader.getTechnologyLabels();
+        this.languageLabels = ConfigLoader.getLanguageLabels();
     }
 
     public void writeRules(Collection<RuleMetadata> rules) throws IOException {
@@ -56,25 +57,38 @@ public class RuleMetadataWriter {
 
     private JsonObject buildItem(Collection<RuleMetadata> rulesById) {
         RuleMetadata first = rulesById.iterator().next();
+
+        JsonObjectBuilder languagesBuilder = Json.createObjectBuilder();
+        rulesById.stream()
+                .sorted(Comparator.comparing(RuleMetadata::getLanguage))
+                .forEach(rule -> languagesBuilder.add(rule.getLanguage(), buildLanguageEntry(rule)));
+
         return Json.createObjectBuilder()
                 .add("id", first.getKey().toString())
                 .add("name", first.getTitle())
                 .add("severity", first.getSeverity().toString())
-                .add("technologies", extractAllProperties(rulesById, RuleMetadata::getTechnology))
-                .add("status", first.getStatus().toString())
+                .add("languages", languagesBuilder.build())
+                .build();
+    }
+
+    private JsonObject buildLanguageEntry(RuleMetadata rule) {
+        return Json.createObjectBuilder()
+                .add("status", rule.getStatus().toString())
                 .build();
     }
 
     private JsonObject buildMeta(Collection<RuleMetadata> rules) {
         String deploymentUrl = System.getenv("PAGES_DEPLOYMENT_URL");
         return Json.createObjectBuilder()
-                .add("technologies", extractAllPropertiesToMap(rules, rule -> Map.entry(
-                        rule.getTechnology(),
-                        technologyLabels.getOrDefault(rule.getTechnology(), rule.getTechnology())
+                .add("languages", extractAllPropertiesToMap(rules, rule -> Map.entry(
+                        rule.getLanguage(),
+                        languageLabels.getOrDefault(rule.getLanguage(), rule.getLanguage())
                 )))
                 .add("severities", extractAllProperties(rules, rule -> rule.getSeverity().toString()))
                 .add("statuses", extractAllProperties(rules, rule -> rule.getStatus().toString()))
-                .add("contentUrlTemplate", deploymentUrl != null ? Json.createValue(deploymentUrl + "{technology}/{id}.html") : JsonValue.NULL)
+                .add("contentUrlTemplate",
+                        deploymentUrl != null ? Json.createValue(deploymentUrl + "{language}/{id}.html")
+                                : JsonValue.NULL)
                 .build();
     }
 
@@ -93,7 +107,10 @@ public class RuleMetadataWriter {
         ).build();
     }
 
-    private JsonObject extractAllPropertiesToMap(Collection<RuleMetadata> rules, Function<RuleMetadata, Map.Entry<String, String>> mapper) {
+    private JsonObject extractAllPropertiesToMap(
+            Collection<RuleMetadata> rules,
+            Function<RuleMetadata, Map.Entry<String, String>> mapper
+    ) {
         JsonObjectBuilder builder = Json.createObjectBuilder();
         rules.stream()
                 .map(mapper)

--- a/maven-build/main/resources/config.json
+++ b/maven-build/main/resources/config.json
@@ -1,5 +1,5 @@
 {
-  "technologies": {
+  "languages": {
     "csharp": "C#",
     "html": "HTML",
     "java": "Java",

--- a/maven-build/test/java/org/greencodeinitiative/mavenbuild/ruleexporter/domain/RuleDescriptionFileTest.java
+++ b/maven-build/test/java/org/greencodeinitiative/mavenbuild/ruleexporter/domain/RuleDescriptionFileTest.java
@@ -35,7 +35,7 @@ class RuleDescriptionFileTest {
         assertThat(result).isPresent();
         RuleDescriptionFile rule = result.get();
         assertThat(rule.getRuleKey().toString()).hasToString("GCI123");
-        assertThat(rule.getTechnology()).isEqualTo("java");
+        assertThat(rule.getLanguage()).isEqualTo("java");
     }
 
     @Test
@@ -51,7 +51,7 @@ class RuleDescriptionFileTest {
         assertThat(result).isPresent();
         RuleDescriptionFile rule = result.get();
         assertThat(rule.getRuleKey().toString()).hasToString("GCI456");
-        assertThat(rule.getTechnology()).isEqualTo("javascript");
+        assertThat(rule.getLanguage()).isEqualTo("javascript");
     }
 
     @Test
@@ -62,7 +62,7 @@ class RuleDescriptionFileTest {
 
         // When & Then
         assertThat(rule.getRuleKey().toString()).hasToString("GCI789");
-        assertThat(rule.getTechnology()).isEqualTo("python");
+        assertThat(rule.getLanguage()).isEqualTo("python");
     }
 
     @Test
@@ -83,25 +83,25 @@ class RuleDescriptionFileTest {
     }
 
     @Test
-    @DisplayName("Should extract technology from various valid paths")
-    void shouldExtractTechnologyFromVariousPaths() {
-        // Test different technologies
+    @DisplayName("Should extract language from various valid paths")
+    void shouldExtractLanguageFromVariousPaths() {
+        // Test different languages
         assertThat(RuleDescriptionFile.createFromPath("path/GCI1/java/GCI1.html"))
                 .isPresent()
                 .get()
-                .extracting(RuleDescriptionFile::getTechnology)
+                .extracting(RuleDescriptionFile::getLanguage)
                 .isEqualTo("java");
 
         assertThat(RuleDescriptionFile.createFromPath("path/GCI2/javascript/GCI2.html"))
                 .isPresent()
                 .get()
-                .extracting(RuleDescriptionFile::getTechnology)
+                .extracting(RuleDescriptionFile::getLanguage)
                 .isEqualTo("javascript");
 
         assertThat(RuleDescriptionFile.createFromPath("path/GCI3/python/GCI3.html"))
                 .isPresent()
                 .get()
-                .extracting(RuleDescriptionFile::getTechnology)
+                .extracting(RuleDescriptionFile::getLanguage)
                 .isEqualTo("python");
     }
 

--- a/maven-build/test/java/org/greencodeinitiative/mavenbuild/ruleexporter/domain/RuleMetadataTest.java
+++ b/maven-build/test/java/org/greencodeinitiative/mavenbuild/ruleexporter/domain/RuleMetadataTest.java
@@ -13,7 +13,7 @@ public class RuleMetadataTest {
     void setUp() {
         ruleMetadata = new RuleMetadata.Builder()
                 .key(new RuleKey("GCI10"))
-                .technology("java")
+                .language("java")
                 .title("title")
                 .severity(RuleSeverity.INFO)
                 .status(RuleStatus.READY)
@@ -23,7 +23,7 @@ public class RuleMetadataTest {
     @Test
     void builder() {
         assertThat(ruleMetadata.getKey()).isEqualTo(new RuleKey("GCI10"));
-        assertThat(ruleMetadata.getTechnology()).isEqualTo("java");
+        assertThat(ruleMetadata.getLanguage()).isEqualTo("java");
         assertThat(ruleMetadata.getTitle()).isEqualTo("title");
         assertThat(ruleMetadata.getSeverity()).isEqualTo(RuleSeverity.INFO);
         assertThat(ruleMetadata.getStatus()).isEqualTo(RuleStatus.READY);
@@ -32,7 +32,6 @@ public class RuleMetadataTest {
     @Test
     void asString() {
         assertThat(ruleMetadata.toString()).isEqualTo(
-                "RuleMetadata{key='GCI10', language='java', title='title', severity=INFO, status=READY}"
-        );
+                "RuleMetadata{key='GCI10', language='java', title='title', severity=INFO, status=READY}");
     }
 }

--- a/maven-build/test/java/org/greencodeinitiative/mavenbuild/ruleexporter/infra/PrepareResourcesTest.java
+++ b/maven-build/test/java/org/greencodeinitiative/mavenbuild/ruleexporter/infra/PrepareResourcesTest.java
@@ -87,8 +87,8 @@ class PrepareResourcesTest {
         FileHelper.mergeJsonFile(sourceJson, mergeJson, targetJson);
 
         // Then
-        String expectedContent =
-                "{\n" + "\"key1\": \"value1\",\n" + "\"key2\": \"newValue2\",\n" + "\"key3\": \"value3\"\n" + "}";
+        String expectedContent = "{\n" + "\"key1\": \"value1\",\n" + "\"key2\": \"newValue2\",\n"
+                + "\"key3\": \"value3\"\n" + "}";
         assertThat(targetJson).exists();
         assertThat(Files.readString(targetJson)).isEqualToIgnoringWhitespace(expectedContent);
     }
@@ -155,7 +155,23 @@ class PrepareResourcesTest {
             JsonObject json = reader.readObject();
             assertThat(json.containsKey("items")).isTrue();
             assertThat(json.containsKey("meta")).isTrue();
-            assertThat(json.getJsonArray("items")).isNotEmpty();
+            assertThat(json.getJsonObject("meta").containsKey("languages")).isTrue();
+
+            JsonObject gci36 = json.getJsonArray("items").stream()
+                    .map(JsonObject.class::cast)
+                    .filter(item -> "GCI36".equals(item.getString("id")))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("GCI36 not found in items"));
+
+            // New per-language structure
+            assertThat(gci36.containsKey("languages")).isTrue();
+            assertThat(gci36.containsKey("status")).isFalse();
+
+            JsonObject languages = gci36.getJsonObject("languages");
+            assertThat(languages.containsKey("html")).isTrue();
+            assertThat(languages.containsKey("javascript")).isTrue();
+            assertThat(languages.getJsonObject("html").getString("status")).isEqualTo("READY");
+            assertThat(languages.getJsonObject("javascript").getString("status")).isEqualTo("DEPRECATED");
         }
     }
 

--- a/maven-build/test/java/org/greencodeinitiative/mavenbuild/ruleexporter/infra/RuleFactoryTest.java
+++ b/maven-build/test/java/org/greencodeinitiative/mavenbuild/ruleexporter/infra/RuleFactoryTest.java
@@ -38,7 +38,7 @@ class RuleFactoryTest {
         assertThat(result).isPresent();
         RuleDescriptionFile rule = result.get();
         assertThat(rule.getRuleKey().toString()).hasToString(GCI_123);
-        assertThat(rule.getTechnology()).hasToString("java");
+        assertThat(rule.getLanguage()).hasToString("java");
     }
 
     @Test
@@ -129,7 +129,7 @@ class RuleFactoryTest {
         Path targetPath = rule.getHtmlDescriptionTargetPath(targetDir);
 
         // Then
-        assertThat(targetPath).isEqualTo(Path.of("target/classes/java/"+ GCI_123 + ".html"));
+        assertThat(targetPath).isEqualTo(Path.of("target/classes/java/" + GCI_123 + ".html"));
     }
 
     @Test
@@ -147,8 +147,8 @@ class RuleFactoryTest {
     }
 
     @Test
-    @DisplayName("Should handle different technologies")
-    void shouldHandleDifferentTechnologies(@TempDir Path tempDir) throws Exception {
+    @DisplayName("Should handle different languages")
+    void shouldHandleDifferentLanguages(@TempDir Path tempDir) throws Exception {
         // Given
         Path ruleDir = Files.createDirectories(tempDir.resolve("GCI456"));
         Path languageDir = Files.createDirectories(ruleDir.resolve("javascript"));
@@ -162,6 +162,6 @@ class RuleFactoryTest {
         assertThat(result).isPresent();
         RuleDescriptionFile rule = result.get();
         assertThat(rule.getRuleKey().toString()).hasToString("GCI456");
-        assertThat(rule.getTechnology()).isEqualTo("javascript");
+        assertThat(rule.getLanguage()).isEqualTo("javascript");
     }
 }

--- a/maven-build/test/resources/rules-html/GCI36/javascript/GCI36.json
+++ b/maven-build/test/resources/rules-html/GCI36/javascript/GCI36.json
@@ -1,13 +1,5 @@
 {
-  "tags": [
-    "creedengo",
-    "eco-design",
-    "react-native",
-    "video",
-    "audio"
-  ],
-  "compatibleLanguages": [
-    "JAVASCRIPT",
-    "TYPESCRIPT"
-  ]
+  "status": "deprecated",
+  "tags": ["creedengo", "eco-design", "react-native", "video", "audio"],
+  "compatibleLanguages": ["JAVASCRIPT", "TYPESCRIPT"]
 }


### PR DESCRIPTION
Replace the flat `technologies` array and single `status` string with a `languages` map where each language entry carries its own set of fields.

Closes #449 